### PR TITLE
Ensure to clear RGB when entering clock mode

### DIFF
--- a/WOPR_Display/WOPR_Display.ino
+++ b/WOPR_Display/WOPR_Display.ino
@@ -889,6 +889,7 @@ void loop()
     if ( hasWiFi && settings_clockCountdownTime > 0 && countdownToClock < millis()  )
     {
       Clear();
+      RGB_Clear(true); // Ensure to clear the RGB LEDs when entering time display mode
       currentMode = CLOCK;
       currentState = RUNNING;
     }


### PR DESCRIPTION
This ensures the RGB strip is off when the clock is displayed.
Otherwise the WOPR is too bright to be used as a bedside clock.