### PR TITLE
bugfix: 12hr clock and settings menu

### DIFF
--- a/WOPR_Display_V2/WOPR_Display_V2.ino
+++ b/WOPR_Display_V2/WOPR_Display_V2.ino
@@ -693,8 +693,12 @@ void DisplayTime()
   int the_hour = timeinfo.tm_hour;
 
   // Adjust for 24 hour display mode
-  if (!settings_24H && the_hour > 12)
-    the_hour -= 12;
+  if (!settings_24H) {
+    if (the_hour > 12)
+      the_hour -= 12;
+    else if (the_hour == 0)
+      the_hour = 12;
+  }
 
   // Padd the time if the hour is a single digit
   if ( the_hour < 10 )

--- a/WOPR_Display_V2/WOPR_Display_V2.ino
+++ b/WOPR_Display_V2/WOPR_Display_V2.ino
@@ -108,7 +108,7 @@ bool isFirstBoot = false;
 String clockSeparators [] = {" ", "-", "_"};
 String stateStrings[] = {"MENU", "RUNNING", "SETTINGS"};
 String menuStrings[] = {"MODE MOVIE", "MODE RANDOM", "MODE MESSAGE", "MODE CLOCK", "SETTINGS"};
-String settingsStrings[] = {"GMT ", "24H MODE ", "BRIGHT ", "NGHT DIM ", "CLK RGB ", "CLK CNT ", "CLK SEP ", "UPDATE GMT"};
+String settingsStrings[] = {"GMT ", "24H MODE ", "BRIGHT ", "CLK RGB ", "CLK CNT ", "CLK SEP ", "UPDATE GMT"};
 
 enum states {
   MENU = 0,
@@ -592,10 +592,10 @@ void UpdateSetting( int dir )
   else if ( currentSetting == SET_SEP )
   {
     settings_separator += dir;
-    if ( settings_separator == 3)
+    if ( settings_separator == ELEMENTS(clockSeparators))
       settings_separator = 0;
     else if ( settings_separator < 0 )
-      settings_separator = 2;
+      settings_separator = ELEMENTS(clockSeparators) - 1;
   }
   else if ( currentSetting == SET_UPDATE_GMT )
   {


### PR DESCRIPTION
WOPR_Display_V2 bugfixes:
- 12 hour clock mode the hour was displaying the hour as "0" and not "12" at midnight
- removed "NGHT DIM" from settingsStrings[] as the dim at night setting is not implemented; there is no entry for it in enum setings{} which throws off the settings display as it uses the value of currentSetting to index settingsStrings[] to pick what string to display to represent the current setting. 

WOPR_Display_V2 code change:
- made use of the ELEMENTS() macro when detecting if the current clock separator setting index is outside the number of available clock separator values rather than using hard-coded values. this makes it easier to add new separators.